### PR TITLE
Updated handler to make POST request to Safira regarding association

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ rocket = { git = "https://github.com/SergioBenitez/Rocket" }
 rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket" }
 lazy_static = "1.4.0"
 reqwest = { version = "0.11.0", features = ['blocking', 'json'] }
+uuid = "0.8"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,10 +1,8 @@
 use crate::{
     config::CONFIG,
-    requests::{AssociationRequest, ErrorReply, LoginReply, LoginRequest},
+    requests::{AssociationRequest, UserType, ErrorReply, LoginReply, LoginRequest},
 };
-use core::time::Duration;
 use lazy_static::lazy_static;
-use phf::phf_map;
 use serenity::{
     async_trait,
     model::{
@@ -16,6 +14,8 @@ use serenity::{
     prelude::*,
 };
 use std::{fs::File, io::BufReader};
+use uuid::Uuid;
+
 lazy_static! {
     pub static ref JWT: String = {
         let login_request: LoginRequest = File::open(&CONFIG.credentials_location)
@@ -42,22 +42,23 @@ lazy_static! {
     };
 }
 
-static ROLES: phf::Map<&'static str, RoleId> = phf_map! {
-    "staff" => RoleId(793534104339349534),
-    "exclusive" => RoleId(793536901201264660),
-    "gold" => RoleId(793536966548652033),
-    "silver" => RoleId(793537012468023328),
-    "orador" => RoleId(793537618138234912),
-    "participante" => RoleId(793536131458531389),
-};
-
-const GUILD_ID: GuildId = GuildId(793533219865755648);
+impl UserType {
+  fn as_role(&self) -> RoleId {
+    match self {
+        Self::Staff => RoleId(793534104339349534),
+        Self::Empresa => RoleId(793536901201264660),     // errado , mudar empresa
+        Self::Orador => RoleId(793537618138234912),
+        Self::Participante => RoleId(793536131458531389),
+    }
+  }
+}
+const GUILD_ID: GuildId = GuildId(769885792038289445);
 pub struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
     async fn guild_member_addition(&self, ctx: Context, _guild_id: GuildId, new_member: Member) {
-        let dm = new_member
+    new_member
             .user
             .dm(&ctx, |m| {
                 m.embed(|e| {
@@ -65,54 +66,53 @@ impl EventHandler for Handler {
                     .description("Para poderes ter acesso a todo o evento, segue o link x e cola aqui o codigo que la encontras para finalizar a tua inscricao")
                 })
             })
-            .await;
-        match dm {
-            Ok(msg) => {
-                let a = msg
-                    .channel_id
-                    .await_reply(&ctx)
-                    .timeout(Duration::from_secs(3600))
-                    .await;
-                if let Some(ms) = a {
-                    println!("{:#}", ms.content);
-                }
-                //now we send to backend ids
-                //and then we recive
-            }
-            Err(why) => println!("Error when direct messaging user: {:?}", why),
-        }
+            .await.unwrap();
     }
 
     async fn message(&self, ctx: Context, new_message: Message) {
-        let _request = AssociationRequest {
-            discord_association_code: new_message.content.to_owned(),
-            discord_id: new_message.author.id.to_string(),
-        };
+        let mut message= String::from("Código inválido, tenta de novo");
         if Message::is_private(&new_message) {
-            if new_message.content == "give me" {
-                let role_id = ROLES
-                    .get("orador")
-                    .expect("Safira, do your job properly pls");
+            let request = AssociationRequest {
+                discord_association_code: new_message.content.to_owned(),
+                discord_id: new_message.author.id.to_string(),
+            };
+            if let Some(role) = Uuid::parse_str(&new_message.content).ok().and_then(|_| request_role(request)){
+                let role_id = UserType::as_role(&role);
                 let member = GUILD_ID.member(&ctx, new_message.author.id).await;
                 match member {
-                    Ok(mut m) => {
-                        let _ = m.add_role(&ctx, role_id).await;
-                    }
-                    Err(e) => println!("{}", e),
+                  Ok(mut m) => {
+                      let _ = m.add_role(&ctx, role_id).await;
+                      message = String::from("O teu id foi validado, vais agora ter acesso aos canais da SEI.");
+                  }
+                  Err(e) => println!("{}", e),
                 }
             }
+        }
             new_message
                 .author
                 .dm(&ctx, |m| {
-                    m.content("Não faço ideia se o teu ID é válido ainda")
+                    m.content(message)
                 })
                 .await
                 .unwrap();
         }
-    }
-
     async fn ready(&self, _: Context, ready: Ready) {
-        //println!("{}", JWT.as_str());
         println!("{} is connected!", ready.user.name);
     }
+}
+
+fn request_role(association_request: AssociationRequest) -> Option <UserType>  {
+         match reqwest::blocking::Client::new()
+            .post(reqwest::Url::parse(format!("{}/association", &CONFIG.backend_ip).as_str()).unwrap())
+            .json(&association_request)
+            .send() {
+               Ok(response) => {
+                    if response.status().is_success() {
+                        Some(response.json::<UserType>().unwrap())
+                    } else {
+                        None
+                    }
+                }
+                _ =>  None
+        }
 }


### PR DESCRIPTION
- Implemented function to make POST request to Safira on `/association` endpoint and attribute the corresponding role to the user.
- Implement response to user informing whether their id was validated.
- Deleted hashmap and created a method for trait UserType which returns a `RoleId`.